### PR TITLE
Make idno/@type optional

### DIFF
--- a/dracor.odd
+++ b/dracor.odd
@@ -4560,7 +4560,7 @@
                   </p>
                 </remarks>
               </attDef>
-              <attDef ident="type" mode="change" usage="req">
+              <attDef ident="type" mode="change" usage="opt">
                 <desc>Classifies the identifier</desc>
                 <valList type="semi" mode="replace">
                   <valItem ident="URL">


### PR DESCRIPTION
In corpora derived from pre-existing TEI we may find `idno` elements without a `type` attribute. For instance in ItaDraCor, e.g.
https://github.com/dracor-org/itadracor/blob/82350161dbc1fac37b408f2c47417595dcf4d442/tei/goldoni-il-servitore-di-due-padroni.xml#L20.

I think, making `@type` optional is a better choice than the alternatives: inventing a type that we any never make use of, just increasing verbosity, or remove the `idno` elements altogether that do no harm and may still be useful for some task in the future.