### PR TITLE
Include p5subset.xml for current TEI version

### DIFF
--- a/build
+++ b/build
@@ -12,18 +12,18 @@ version=$(git describe --tags --dirty --always | sed s/^v// | sed s/-g/-/)
 mkdir -p dist
 
 # Generate full ODD
-$BIN/teitoodd --odd dracor.odd dist/dracor.odd.tmp
+$BIN/teitoodd --localsource=p5subset.xml --odd dracor.odd dist/dracor.odd.tmp
 
 # Transform to RNG
-$BIN/teitorng --odd dist/dracor.odd.tmp dist/dracor.rng
+$BIN/teitorng --localsource=p5subset.xml --odd dist/dracor.odd.tmp dist/dracor.rng
 sed -i.bak -E -e "s/(DraCor Schema)/\1 $version/" dist/dracor.rng
 
 # Transform to Schematron
-$BIN/teitoschematron --odd dist/dracor.odd.tmp dist/dracor.sch
+$BIN/teitoschematron --localsource=p5subset.xml --odd dist/dracor.odd.tmp dist/dracor.sch
 sed -i.bak -E -e "s/(<title>ISO Schematron rules)/\1 (DraCor Schema $version)/" dist/dracor.sch
 
 # Transform to HTML
-$BIN/teitohtml --odd dist/dracor.odd.tmp dist/dracor.html.tmp
+$BIN/teitohtml --localsource=p5subset.xml --odd dist/dracor.odd.tmp dist/dracor.html.tmp
 java -jar Stylesheets/lib/saxon10he.jar \
   -xsl:html.xsl \
   -s:dist/dracor.html.tmp \


### PR DESCRIPTION
Until there is a solution for https://github.com/TEIC/TEI/issues/2779 let's include the p5subset.xml corresponding to the TEI version we rely on and use it when building the schema.

This PR is an attempt to remedy the problem of #143. However, looking at the RNG generated with the current p5subset.xml, there is no significant difference to the one generated with the subset that ships with the Stylesheets.