### PR TITLE
Implement schematron rule checking either xml-model or `/TEI/@type`

### DIFF
--- a/dracor.odd
+++ b/dracor.odd
@@ -350,11 +350,34 @@
             EzDrama language</ref>!).
           </p>
           <p rend="hint">
-            If you’re using Oxygen Editor, you can download and try the
-            experimental <ref target="https://github.com/dracor-org/dracor-oxygen-framework">DraCor
+            If you’re using the Oxygen editor, you can install the
+            <ref target="https://github.com/dracor-org/dracor-oxygen-framework?tab=readme-ov-file#usage">DraCor
             Oxygen Framework</ref>. It will help you by checking many kinds of
             inconsistencies in the markup and validating your file against the
             DraCor schema.
+          </p>
+          <p>
+            We recommend to explicitly reference the DraCor schema in an
+            <code>xml-model</code> processing instruction like this:
+            <!-- escaping the processing instruction in the example to avoid
+                 messing up vscode's validation and loosing it in the HTML
+                 rendering -->
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">&lt;?xml-model href="https://dracor.org/schema.rng" schematypens="http://relaxng.org/ns/structure/1.0" type="application/xml" ?&gt;
+              <TEI>
+                <!-- ... -->
+              </TEI>
+            </egXML>
+          </p>
+          <p>
+            If for some reason you prefer not to use a processing instruction a
+            <att>type</att> attribute with the value <val>dracor</val> can be
+            used to associate the document with the DraCor schema in Oxygen
+            (with the DraCor framework installed):
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <TEI type="dracor">
+                <!-- ... -->
+              </TEI>
+            </egXML>
           </p>
         </div>
         <!-- /overview -->

--- a/dracor.odd
+++ b/dracor.odd
@@ -5825,6 +5825,29 @@
                 <elementRef key="text" minOccurs="1" maxOccurs="1"/>
               </sequence>
             </content>
+            <constraintSpec ident="xml_model_or_type_dracor_on_root_tei_element"
+              scheme="schematron" mode="add">
+              <desc>
+                DraCor TEI documents should either reference the DraCor Schema
+                in an <code>&lt;?xml-model ... ?&gt;</code> processing
+                instruction or add a <att>type</att> <val>dracor</val> to their
+                root element.
+              </desc>
+              <constraint>
+                <sch:rule context="/tei:TEI" role="warning">
+                  <sch:assert test="@type = 'dracor' or /processing-instruction('xml-model')">
+                    The root <sch:name/> element should have a @type="dracor"
+                    attribute if the schema is not reference in an xml-model PI.
+                  </sch:assert>
+                  <sch:assert
+                    test="not(/processing-instruction('xml-model')) or (some $pi in /processing-instruction('xml-model')
+                          satisfies matches($pi, 'href\s*=\s*[&quot;'']https://dracor\.org/schema\.rng[&quot;'']'))">
+                    The DraCor schema should be refrerenced as
+                    "https://dracor.org/schema.rng" when using a xml-model PI.
+                  </sch:assert>
+                </sch:rule>
+              </constraint>
+            </constraintSpec>
             <constraintSpec ident="valid_dracor_ids_on_root_tei_element"
               scheme="schematron" mode="add" corresp="#play_id">
               <desc>
@@ -5863,7 +5886,7 @@
             </attList>
             <exemplum source="https://dracor.org/id/ger000171">
               <egXML xmlns="http://www.tei-c.org/ns/Examples">
-                <TEI xml:id="ger000171" xml:lang="ger">
+                <TEI type="dracor" xml:id="ger000171" xml:lang="ger">
                   <!-- ... -->
                 </TEI>
               </egXML>

--- a/tests/tst000000-base.xml
+++ b/tests/tst000000-base.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Basic file to test the features of DraCor plays -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000001-bad-play-wikidata-id.xml
+++ b/tests/tst000001-bad-play-wikidata-id.xml
@@ -11,7 +11,7 @@ obviously not the right QID for this "play".
 
 There should be a warning.
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000001" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000001" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000002-feature-play-wikidata-id.xml
+++ b/tests/tst000002-feature-play-wikidata-id.xml
@@ -12,7 +12,7 @@ obviously not the right QID for this "play".
 There should be an information that the feature "play_wikidata_id" is supported
 and the value should be "Q41567".
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000002" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000002" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000004-ab.xml
+++ b/tests/tst000004-ab.xml
@@ -3,7 +3,7 @@
 This file tests the schematron rule that detects the use of the element <ab>
 at other places than in <license>.
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000004" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000004" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000005-body-incomplete.xml
+++ b/tests/tst000005-body-incomplete.xml
@@ -5,7 +5,7 @@ Incomplete <body>: There is nothing there
 Should throw a critical error from the RelaxNG and also a warning that the
 structure does not allow for the extraction of networks.
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000005" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000005" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000006-div-type-missing.xml
+++ b/tests/tst000006-div-type-missing.xml
@@ -5,7 +5,7 @@ Missing structure: there are no @type attributes on the structural divisions
 Should throw critical errors from the RelaxNG because the attribute @type is
 required.
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000006" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000006" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000007-div-type-value.xml
+++ b/tests/tst000007-div-type-value.xml
@@ -2,7 +2,7 @@
 <!--
 Structural problems: invalid value of @type on a structural division
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000007" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000007" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000008-no-structure.xml
+++ b/tests/tst000008-no-structure.xml
@@ -7,7 +7,7 @@ schema because we expect <div> elements to have a @type attribute. The warnings
 will indicate that there are no <sp> elements. Network data can not be
 extracted.
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000008" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000008" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000009-no-sp.xml
+++ b/tests/tst000009-no-sp.xml
@@ -3,7 +3,7 @@
 This file is valid against the DraCor schema but it is lacking <sp> elements. A
 network can not be extracted. There should be a warning.
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000008" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000008" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000010-no-speakers.xml
+++ b/tests/tst000010-no-speakers.xml
@@ -3,7 +3,7 @@
 Special case: a pantomime – there are no speaking characters. The warning about
 the missing speech acts could be ignored?
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000010" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000010" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000011-rend-braced.xml
+++ b/tests/tst000011-rend-braced.xml
@@ -4,7 +4,7 @@ Curly Brackets to indicate a castGroup
 
 This is the correct encoding using attribute @rend with the value "braced"
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000011" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000011" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000012-rend-braced-wrong.xml
+++ b/tests/tst000012-rend-braced-wrong.xml
@@ -4,7 +4,7 @@ Curly Brackets to indicate a castGroup
 
 WRONG encoding, should be @rend with the value "braced"; here it is "bracket"
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000011" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000011" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000013-sex.xml
+++ b/tests/tst000013-sex.xml
@@ -3,7 +3,7 @@
 Test case to test schematron rules for @sex attributes on <person> and
 <personGrp> elements.
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000014-no-subtitle.xml
+++ b/tests/tst000014-no-subtitle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Warning about missing type="sub" with multiple title elements -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000015-lang-no-subtitle.xml
+++ b/tests/tst000015-lang-no-subtitle.xml
@@ -3,7 +3,7 @@
 Multiple titles with different languages should not trigger a warning about
 missing type="sub".
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000016-title-main-sub.xml
+++ b/tests/tst000016-title-main-sub.xml
@@ -2,7 +2,7 @@
 <!--
 titleStmt with both type="main" and type="sub" title elements is valid
 -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
+<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/tests/tst000017-xml-model.xml
+++ b/tests/tst000017-xml-model.xml
@@ -1,17 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-This file tests the schematron rule to check for the correct encoding of the the
-DraCor ID.
-
-This file has an error in the encoding of the Self-URI in the attribute @active
-in the <standOff><listRelation>.
-
-Here the value is "https://dracor.org/entity/no-such-id" while it SHOULD be
-"https://dracor.org/entity/tst000003".
-
-There should be a Warning displayed.
--->
-<TEI type="dracor" xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000003" xml:lang="eng">
+<?xml-model href="https://dracor.org/schema.rng" schematypens="http://relaxng.org/ns/structure/1.0" type="application/xml" ?>
+<!-- File with xml-model referencing Dracor Schema is valid without TEI/@type  -->
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000017" xml:lang="eng">
   <teiHeader>
     <fileDesc>
       <titleStmt>
@@ -68,14 +58,6 @@ There should be a Warning displayed.
         <desc/>
       </event>
     </listEvent>
-    <listRelation>
-      <!-- We expect a warning here -->
-      <relation
-        name="wikidata"
-        active="https://dracor.org/entity/no-such-id"
-        passive="http://www.wikidata.org/entity/Q41567"
-      />
-    </listRelation>
   </standOff>
   <text>
     <front>

--- a/tests/tst100000-corpus.xml
+++ b/tests/tst100000-corpus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<teiCorpus xmlns="http://www.tei-c.org/ns/1.0">
+<teiCorpus type="dracor" xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>
     <fileDesc>
       <titleStmt>


### PR DESCRIPTION
This rule requires the a DraCor document to either reference the schema in a xml-model processing instruction or adding a `type="dracor"` to the root element. Having a type attribute allows us to constrain the document type association in the DraCor Oxygen framework to DraCor documents only and thus allow it to coexist with the TEI P5 and other frameworks.