### PR TITLE
Include entire namesdates module

### DIFF
--- a/dracor.odd
+++ b/dracor.odd
@@ -2808,8 +2808,7 @@
           <moduleRef key="linking"/>
           <moduleRef key="drama"/>
           <moduleRef key="verse"/>
-          <moduleRef key="namesdates"
-            include="addName event forename genName listEvent listPerson listRelation nameLink person personGrp persName relation surname orgName region"/>
+          <moduleRef key="namesdates"/>
           <moduleRef key="corpus" include="particDesc"/>
           <moduleRef key="figures" include="figure"/>
           <moduleRef key="analysis"/>


### PR DESCRIPTION
We have repeatedly added individual elements from the `namesdates` module and requests for more keep coming in. Let's therefore include the entire module into the DraCor schema. 

resolve #132
resolve #153