### PR TITLE
Fix constraint for @who attribute values

### DIFF
--- a/dracor.odd
+++ b/dracor.odd
@@ -5740,28 +5740,25 @@
                 constructed by prepending the character ID with a hash '#'.
               </desc>
               <constraint>
-                <!-- this works only for @who attributes that contain a single
-                     character only -->
-                <sch:rule context="tei:sp[@who[not(contains(.,' '))]]" role="warning">
-                  <sch:let name="localID" value="replace(@who/string(),'#','')"/>
-                  <sch:assert test="ancestor::tei:TEI//tei:particDesc//(tei:person|tei:personGrp)[@xml:id eq $localID]"
-                    role="warning">
-                    A speech act SHOULD link to a 'person' or 'personGrp'
-                    element in 'particDesc'. Use a valid character ID and
-                    provide it as a pointer by prepending it with a hash '#'."
+                <sch:rule context="tei:sp[@who]">
+                  <sch:let name="refs" value="tokenize(normalize-space(@who), '\s+')" />
+
+                  <sch:assert test="every $r in $refs satisfies starts-with($r, '#')">
+                    References in @who must start with "#".
                   </sch:assert>
-                </sch:rule>
-                <!-- the following rule can detect the cases where there are
-                     multiple character ids in the who attribute -->
-                <sch:rule context="tei:sp[contains(@who,' ')]">
-                  <sch:let name="allIDs" value="./ancestor::tei:TEI//tei:particDesc//(tei:person|tei:personGrp)/@xml:id/string()"/>
-                  <sch:let name="localIDs" value="tokenize(@who/string(),'\s+')"/>
-                  <sch:assert test="every $i in $localIDs satisfies replace($i,'#','') = $allIDs"
-                    role="warning">
-                    At least one character ID provided as the value of the
-                    attribute who '<sch:value-of select="@who/string()"/>' has
-                    not been declared. A speech act SHOULD link to a 'person' or
-                    'personGrp' element in 'particDesc'.
+
+                  <sch:let name="local-ids"
+                    value="for $r in $refs return replace($r,'#','')" />
+
+                  <sch:let name="valid-ids"
+                    value="ancestor::tei:TEI//tei:particDesc//(tei:person|tei:personGrp)[@xml:id]/@xml:id" />
+
+                  <sch:let name="missing"
+                    value="distinct-values($local-ids[not(. = $valid-ids)])" />
+
+                  <sch:assert test="empty($missing)" role="warning">
+                    One or more @who values do not refer to valid IDs in
+                    particDesc: <sch:value-of select="$missing"/>
                   </sch:assert>
                 </sch:rule>
               </constraint>

--- a/tests/tst000018-who-references.xml
+++ b/tests/tst000018-who-references.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Test for invalid references in sp/@who -->
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="dracor" xml:id="tst000000" xml:lang="eng">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Ham</title>
+        <title type="sub">A Tragedy</title>
+        <author>William S</author>
+      </titleStmt>
+      <publicationStmt>
+        <publisher xml:id="dracor">DraCor</publisher>
+        <idno type="URL">https://dracor.org</idno>
+        <availability>
+          <licence target="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0</licence>
+        </availability>
+      </publicationStmt>
+      <sourceDesc>
+        <bibl type="digitalSource">
+          <name>dracor-schema GitHub Repository</name><bibl type="originalSource">
+            <title>Slides of the Hebrew and Yiddish DraCor Working group meeting on 2022-11-14 by Daniil Skorinkin</title>
+          </bibl>
+        </bibl>
+      </sourceDesc>
+    </fileDesc>
+    <profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="ham">
+            <persName>Ham</persName>
+          </person>
+          <person xml:id="egg">
+            <persName>Egg</persName>
+          </person>
+          <person xml:id="sausage">
+            <persName>Sausage</persName>
+          </person>
+          <person xml:id="bacon">
+            <persName>Bacon</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-11-07">Describe Change!</change>
+    </revisionDesc>
+  </teiHeader>
+  <standOff>
+    <listEvent>
+      <event type="print" when="2023">
+        <desc/>
+      </event>
+      <event type="written" when="2022">
+        <desc/>
+      </event>
+    </listEvent>
+  </standOff>
+  <text>
+    <front>
+      <div type="front">
+        <head>Ham, a tragedy By William S</head>
+      </div>
+      <castList>
+        <head>Dramatis Personae</head>
+        <castItem>Ham</castItem>
+        <castItem>Egg</castItem>
+        <castGroup>
+          <castItem>Sausage</castItem>
+          <castItem>Bacon</castItem>
+          <roleDesc>Vikings</roleDesc>
+        </castGroup>
+      </castList>
+    </front>
+    <body>
+      <div type="act">
+        <head>Act 1.</head>
+        <div type="scene">
+          <head>Scene 1.</head>
+          <stage>Ham and Egg.</stage>
+          <sp who="#ham">
+            <speaker>Ham.</speaker>
+            <p>Lovely Spam!</p>
+          </sp>
+          <sp who="#egg">
+            <speaker>Egg.</speaker>
+            <p>Wonderful Spam!</p>
+          </sp>
+        </div>
+        <div type="scene">
+          <head>Scene 2.</head>
+          <stage>Enter Vikings.</stage>
+          <sp who="#ham">
+            <speaker>Ham.</speaker>
+            <p>Egg! Sausage, and Bacon!</p>
+          </sp>
+          <!-- 
+            This @who should result in an error (missing '#') and a warning
+            about a reference not to be found in particDesc for "nosuchid"
+          -->
+          <sp who="#sausage bacon #nosuchid">
+            <speaker>Vikings</speaker>
+            <stage>(singing).</stage>
+            <l>Spam, Spam, Spam,</l>
+            <l>Spam, Spam, Spam,</l>
+            <l>Spam and Spam!</l>
+          </sp>
+          <stage>The End.</stage>
+        </div>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
This now makes sure we have only internal references (no missing "#") and there is a match in particDesc for each of the references if there are more than one.

resolve #134