### PR TITLE
Add bylines with authors

### DIFF
--- a/dracor.odd
+++ b/dracor.odd
@@ -79,6 +79,16 @@
       <titlePage>
         <titlePart type="main">Drama Corpora | dracor.org</titlePart>
         <titlePart type="sub">TEI Customisation and Documentation</titlePart>
+        <byline>
+          By
+          <docAuthor>Ingo Börner</docAuthor>
+          <docAuthor>Frank Fischer</docAuthor>
+          <docAuthor>Luca Giovannini</docAuthor>
+          <docAuthor>Carsten Milling</docAuthor>
+          <docAuthor>Daniil Skorinkin</docAuthor>
+          <docAuthor>Peer Trilcke</docAuthor>
+        </byline>
+        <byline>With contributions by <docAuthor>Angelika Hechtl</docAuthor></byline>
         <docDate>2025</docDate>
       </titlePage>
       <divGen type="toc"/>


### PR DESCRIPTION
This adds the authors listed in the `teiHeader` as a `byline` to the ODD's `titlePage`.

resolve #172