### PR TITLE
A (hopefully) more succinct "Sources" section

### DIFF
--- a/dracor.odd
+++ b/dracor.odd
@@ -694,14 +694,14 @@
           <div xml:id="section-sources">
             <head>Sources</head>
             <p>
-              The sourceDesc <gi>sourceDesc</gi> inside the <gi>fileDesc</gi>
+              The <gi>sourceDesc</gi> inside the <gi>fileDesc</gi>
               element documents the sources used to create the DraCor TEI file.
-              In the DraCor context we are particularly interested in two kinds of 
-              source information. In most cases our TEI file is based on a prior
-              digital file or resource.
+              In the DraCor context, we are particularly interested in two kinds of 
+              source information. In most cases, our DraCor TEI file is directly
+              based on a prior digital file or resource.
               This is what we call the <ref target="#section-digital-source">digital
-              source</ref>. This file is usually based on a printed edition or, in
-              some cases, a manuscript of a play which we refer to as the 
+              source</ref>. In turn, this file is usually based on a printed edition
+              or, in some cases, a manuscript of a play which we refer to as the 
               <ref target="#section-original-source">original source</ref>.
             </p>
             <p>
@@ -743,10 +743,12 @@
             <p>
               While this should cover the majority of cases, we are aware that
               some projects may require a more detailed documentation of their
-              sources. These are free to add additional <gi>bibl</gi> or
-              <gi>biblStruct</gi> elements. Corpus maintainers may also consider
-              including more detailed explanations in a <gi>notesStmt</gi>
-              element.
+              sources. These projects are free to use additional <gi>bibl</gi> or
+              <gi>biblStruct</gi> elements, e.g. for documenting intermediary
+              sources between the <ref target="#section-digital-source">digital
+              source</ref> and the <ref target="#section-original-source">original
+              source</ref>. Corpus maintainers may also consider including more
+              detailed explanations in a <gi>notesStmt</gi> element.
               <note place="bottom">
                 For an exemplary analysis of sources of a corpus, see chapter
                 <ref target="https://versioning-living-corpora.clsinfra.io/3-2_gerdracor_corpus_archeology.html#a-living-corpus-growing">An
@@ -765,7 +767,8 @@
                 Gutenberg</ref>, or
                 <ref target="https://www.let.leidenuniv.nl/Dutch/Ceneton/">CENETON</ref>.
                 Another class of digital sources are digitisations of printed
-                texts or manuscripts, e.g. those by
+                texts or manuscripts published with an identifier and/or under a certain
+                licence, e.g. those by
                 <ref target="https://books.google.com/">Google Books</ref> or the
                 <ref target="https://www.digitale-sammlungen.de/">Munich
                 Digitization Center (MDZ)</ref>.
@@ -812,7 +815,7 @@
               </egXML>
               <p>
                 If the digital source is not published under a specific licence
-                you can link to, licencing information can also be provided as
+                you can link to, licensing information may also be provided as
                 free text as in this example from
                 <ref target="https://dracor.org/id/neolat000001">Macropedius:
                 Hecastus</ref>:
@@ -824,7 +827,7 @@
                   </ref>
                   <availability status="free">
                     <p>
-                      The editions in the website edited by Antonius Harmsen
+                      The editions on the website edited by Antonius Harmsen
                       (Leiden University) are public domain. See
                       https://www.let.leidenuniv.nl/Dutch/Canonisations.html
                     </p>
@@ -832,14 +835,15 @@
                 </bibl>
               </egXML>
               <p>
-                Note that the DraCor API currently recognizes only a single
-                digitial source. Any additional <gi>bibl</gi> with <att>type</att>
+                Note that the DraCor API currently recognises only a single
+                digital source. Any additional <gi>bibl</gi> with <att>type</att>
                 <val>digitalSource</val> will be ignored.
               </p>
               <p>
                 The digital source information is not considered mandatory by the
-                DraCor schema. However it should always be provided unless the 
-                TEI file was directly derived from a print or manuscript source.
+                DraCor schema. However, it should always be provided unless the 
+                DraCor TEI file was directly derived from a print or manuscript
+                source.
               </p>
             </div>
             <div xml:id="section-original-source">
@@ -847,16 +851,16 @@
               <p>
                 The <soCalled>original source</soCalled> is the bibliographic
                 reference to the print publication or manuscript that has
-                provided the copy text for the digital source or, in rarer
+                provided the copy-text for the digital source or, in rarer
                 cases of direct transcription, for the DraCor TEI file itself.
               </p>
               <p>
                 The original source information is considered mandatory by
-                the Dracor schema.
+                the DraCor schema.
               </p>
               <p>
                 It is encoded in a <gi>bibl</gi> element with <att>type</att> 
-                <val>originalSource</val>. The normalized text content of this
+                <val>originalSource</val>. The normalised text content of this
                 element is exposed in the
                 <ref target="#play_original_source_full_citation">originalSource</ref>
                 property of the DraCor API.
@@ -871,7 +875,7 @@
                 </bibl>
               </egXML>
               <p>
-                By explicitly marking up the parts of the bibliographic reference
+                By explicitly marking up the parts of the bibliographic reference,
                 additional properties can be exposed via the DraCor API:
               </p>
               <egXML xmlns="http://www.tei-c.org/ns/Examples">
@@ -893,6 +897,8 @@
                 <ref target="#play_original_source_publication_place">originalSourcePubPlace</ref>,
                 <ref target="#play_original_source_publisher">originalSourcePublisher</ref>,
                 <ref target="#play_original_source_publication_year">originalSourceYear</ref>.
+                They are also the basis for downloading the metadata via the
+                DraCor Frontend.
               </p>
             </div>
           </div>


### PR DESCRIPTION
Hi @juliajbeine, this is how I would like to revise your latest version of the "Sources" section. It tries to put more emphasis on the common situation reducing the discussion of edge cases and also links the markup description to the API features documentation. What do you think?