### PR TITLE
Add constraint for `idno` elements of type "wikidata"

### DIFF
--- a/dracor.odd
+++ b/dracor.odd
@@ -4961,6 +4961,21 @@
 
           <!-- idno -->
           <elementSpec ident="idno" module="header" mode="change">
+            <constraintSpec ident="idno_wikidata_qid" scheme="schematron" mode="add">
+              <desc>
+                The content of an <gi>idno</gi> with <att>type</att>
+                <val>wikidata</val> must be a Wikidata QID (e.g.
+                <val>Q42</val>), not a full URL.
+              </desc>
+              <constraint>
+                <sch:rule context="tei:idno[@type eq 'wikidata']">
+                  <sch:assert test="matches(normalize-space(.), '^Q[1-9]\d*$')">
+                    The content of an &lt;idno type="wikidata"&gt; must be a
+                    Wikidata QID, e.g. "Q42", not a full URL.
+                  </sch:assert>
+                </sch:rule>
+              </constraint>
+            </constraintSpec>
             <attList>
               <attDef ident="xml:base" mode="change" usage="opt">
                 <desc>


### PR DESCRIPTION
These are supposed to hold the QID only, not a full URL.

resolve #61 