### PR TITLE
Use <idno type="wikidata"> for character Wikidata IDs

### DIFF
--- a/dracor.odd
+++ b/dracor.odd
@@ -1418,21 +1418,31 @@
                 <head>Characters as Realisations of Concepts</head>
                 <p>
                   If a character in a play is an actualisation of a character
-                  archetype, e.g. a mythological figure or a historical person, it is
-                  possible to provide a link to the entity on Wikidata by
-                  including the full URI in the attribute <att>ana</att>.
+                  archetype, e.g. a mythological figure or a historical person,
+                  it is possible to provide a link to the entity on Wikidata. 
+                  The Wikidata QID is encoded as an <gi>idno</gi> element with
+                  <att>type</att> <val>wikidata</val> inside the <gi>person</gi>
+                  or <gi>personGrp</gi> element.
                 </p>
                 <p>
                   <egXML xmlns="http://www.tei-c.org/ns/Examples">
-                    <person xml:id="medea" sex="FEMALE" ana="http://www.wikidata.org/entity/Q174278">
+                    <person xml:id="medea" sex="FEMALE">
                       <persName>Medea</persName>
+                      <idno type="wikidata">Q174278</idno>
                     </person>
                   </egXML>
                   <egXML xmlns="http://www.tei-c.org/ns/Examples">
-                    <person xml:id="napoleon" sex="MALE" ana="http://www.wikidata.org/entity/Q517">
+                    <person xml:id="napoleon" sex="MALE">
                       <persName>Napoleon</persName>
+                      <idno type="wikidata">Q517</idno>
                     </person>
                   </egXML>
+                </p>
+                <p>
+                  The use of the <att>ana</att> attribute with a full Wikidata
+                  URI (e.g. <val>http://www.wikidata.org/entity/Q174278</val>)
+                  is deprecated. Use the migration stylesheet
+                  <code>007-ana-to-idno.xsl</code> to update existing files.
                 </p>
               </div>
               <!-- /character realizations -->
@@ -3097,6 +3107,13 @@
               <p>
                 Feature <idno type="feature-no">Ch5</idno>
                 <idno type="feature-id">character_wikidata_id</idno>:
+                Wikidata QID of the real-world entity (e.g. a mythological
+                figure or historical person) that a character represents.
+                Encoded as <gi>idno</gi> with <att>type</att>
+                <val>wikidata</val> inside the <gi>person</gi> or
+                <gi>personGrp</gi> element (see
+                <ref target="#section-character-concept-realizations">Characters
+                as Realisations of Concepts</ref>).
               </p>
             </div>
             <div xml:id="character_node_betweenness">
@@ -5833,6 +5850,26 @@
 
           <!-- person -->
           <elementSpec ident="person" module="core" mode="change">
+            <constraintSpec ident="person_ana_wikidata_deprecation" scheme="schematron" mode="add">
+              <desc>
+                Deprecation: use <gi>idno</gi> with <att>type</att>
+                <val>wikidata</val> instead of <att>ana</att> for Wikidata
+                links on <gi>person</gi>.
+              </desc>
+              <constraint>
+                <sch:rule
+                  context="tei:particDesc//tei:person[@ana]"
+                  see="https://dracor.org/doc/odd#section-character-concept-realizations"
+                  role="warning"
+                >
+                  <sch:report test="starts-with(@ana, 'http://www.wikidata.org/entity/')">
+                    Using @ana for Wikidata links on &lt;person&gt; is
+                    deprecated. Use &lt;idno type="wikidata"&gt;Q…&lt;/idno&gt;
+                    instead. Apply migration 007-ana-to-idno.xsl to update.
+                  </sch:report>
+                </sch:rule>
+              </constraint>
+            </constraintSpec>
             <constraintSpec ident="person_sex" scheme="schematron" mode="add"  type="encoding-hint">
               <constraint>
                 <sch:rule context="tei:person[@sex]" role="warning" see="https://dracor.org/doc/odd#section-character-sex-gender">
@@ -5888,6 +5925,26 @@
 
           <!-- personGrp -->
           <elementSpec ident="personGrp" module="namesdates" mode="change">
+            <constraintSpec ident="personGrp_ana_wikidata_deprecation" scheme="schematron" mode="add">
+              <desc>
+                Deprecation: use <gi>idno</gi> with <att>type</att>
+                <val>wikidata</val> instead of <att>ana</att> for Wikidata
+                links on <gi>personGrp</gi>.
+              </desc>
+              <constraint>
+                <sch:rule
+                  context="tei:particDesc//tei:personGrp[@ana]"
+                  see="https://dracor.org/doc/odd#section-character-concept-realizations"
+                  role="warning"
+                >
+                  <sch:report test="starts-with(@ana, 'http://www.wikidata.org/entity/')">
+                    Using @ana for Wikidata links on &lt;personGrp&gt; is
+                    deprecated. Use &lt;idno type="wikidata"&gt;Q…&lt;/idno&gt;
+                    instead. Apply migration 007-ana-to-idno.xsl to update.
+                  </sch:report>
+                </sch:rule>
+              </constraint>
+            </constraintSpec>
             <constraintSpec ident="personGrp_sex" scheme="schematron" mode="add"  type="encoding-hint">
               <constraint>
                 <sch:rule context="tei:personGrp[@sex]" role="warning" see="https://dracor.org/doc/odd#section-character-sex-gender">
@@ -6869,6 +6926,26 @@
                   The Wikidata ID is expected to be wrapped in an &lt;idno&gt;
                   element and must match the regular expression "Q[1-9]\d*".
                 </sch:assert>
+              </sch:rule>
+            </constraint>
+          </constraintSpec>
+
+          <!-- Feature Checks: Character Features -->
+          <!-- Ch5  character_wikidata_id -->
+          <constraintSpec ident="character_wikidata_id" scheme="schematron"
+            type="api_feature_check" corresp="#character_wikidata_id">
+            <desc>
+              Feature-Check:
+              <name type="api_feature">
+                <ref target="#character_wikidata_id">Ch5 character_wikidata_id</ref>
+              </name>
+            </desc>
+            <constraint>
+              <sch:rule context="/" role="information" see="https://dracor.org/doc/odd#character_wikidata_id">
+                <sch:report
+                  test="//tei:particDesc//(tei:person|tei:personGrp)/tei:idno[@type eq 'wikidata'][matches(normalize-space(.), '^Q[1-9]\d*$')]">
+                  Supported API feature: character_wikidata_id
+                </sch:report>
               </sch:rule>
             </constraint>
           </constraintSpec>

--- a/migrations/007-ana-to-idno.xsl
+++ b/migrations/007-ana-to-idno.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Convert @ana Wikidata URIs on person/personGrp to <idno type="wikidata">
+  https://github.com/dracor-org/dracor-schema/issues/130
+-->
+<xsl:stylesheet
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:tei="http://www.tei-c.org/ns/1.0"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.tei-c.org/ns/1.0"
+  exclude-result-prefixes="tei xs"
+  version="3.0">
+
+  <xsl:output method="xml" />
+
+  <xsl:template
+    match="tei:particDesc//(tei:person|tei:personGrp)[@ana[starts-with(., 'http://www.wikidata.org/entity/Q')]]">
+    <xsl:variable name="last-ws" as="text()?"
+      select="text()[last()][normalize-space() = '']"/>
+    <xsl:variable name="first-ws" as="text()?"
+      select="text()[1][normalize-space() = '']"/>
+    <xsl:variable name="parent-indent" as="xs:string"
+      select="if ($last-ws) then tokenize($last-ws, '\n')[last()] else ''"/>
+    <xsl:variable name="child-indent" as="xs:string"
+      select="
+        if ($first-ws)
+        then tokenize($first-ws, '\n')[last()]
+        else concat($parent-indent, '  ')"/>
+    <xsl:copy copy-namespaces="no">
+      <xsl:apply-templates select="@* except @ana"/>
+      <xsl:apply-templates select="node() except $last-ws"/>
+      <xsl:text>&#10;</xsl:text>
+      <xsl:value-of select="$child-indent"/>
+      <idno type="wikidata">
+        <xsl:value-of select="substring-after(@ana, 'entity/')"/>
+      </idno>
+      <xsl:if test="$last-ws">
+        <xsl:value-of select="$last-ws"/>
+      </xsl:if>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="@*|*|processing-instruction()|comment()|node()">
+    <xsl:copy copy-namespaces="no">
+      <xsl:apply-templates select="@*|*|processing-instruction()|comment()|node()"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/tests/tst000024-feature-character-wikidata-id.xml
+++ b/tests/tst000024-feature-character-wikidata-id.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file tests the schematron rule to check for the correct encoding of a
+character Wikidata ID using <idno type="wikidata">.
+
+There should be an information that the feature "character_wikidata_id" is
+supported.
+-->
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="dracor" xml:id="tst000024" xml:lang="en">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Ham</title>
+        <title type="sub">A Tragedy</title>
+        <author>William S</author>
+      </titleStmt>
+      <publicationStmt>
+        <publisher xml:id="dracor">DraCor</publisher>
+        <idno type="URL">https://dracor.org</idno>
+        <availability>
+          <licence target="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0</licence>
+        </availability>
+      </publicationStmt>
+      <sourceDesc>
+        <bibl type="digitalSource">
+          <ref target="https://github.com/dracor-org/dracor-schema">
+            dracor-schema GitHub Repository
+          </ref>
+          <availability>
+            <licence target="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</licence>
+          </availability>
+        </bibl>
+        <bibl type="originalSource">
+          Slides of the Hebrew and Yiddish DraCor Working group meeting on
+          2022-11-14 by Daniil Skorinkin
+        </bibl>
+        <listEvent>
+          <event type="print" when="2023">
+            <desc/>
+          </event>
+          <event type="written" when="2022">
+            <desc/>
+          </event>
+        </listEvent>
+      </sourceDesc>
+    </fileDesc>
+    <profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="ham">
+            <persName>Ham</persName>
+          </person>
+          <person xml:id="medea" sex="FEMALE">
+            <persName>Medea</persName>
+            <idno type="wikidata">Q174278</idno>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-11-07">Describe Change!</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <front>
+      <div type="front">
+        <head>Ham, a tragedy By William S</head>
+      </div>
+    </front>
+    <body>
+      <div type="act">
+        <head>Act 1.</head>
+        <div type="scene">
+          <head>Scene 1.</head>
+          <stage>Ham and Medea.</stage>
+          <sp who="#ham">
+            <speaker>Ham.</speaker>
+            <p>Lovely Spam!</p>
+          </sp>
+          <sp who="#medea">
+            <speaker>Medea.</speaker>
+            <p>Wonderful Spam!</p>
+          </sp>
+        </div>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/tests/tst000025-deprecate-ana-wikidata.xml
+++ b/tests/tst000025-deprecate-ana-wikidata.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file tests the deprecation warning for using @ana with a Wikidata URI on
+<person> elements.
+
+The deprecation report should fire for the person element using @ana.
+Apply migration 007-ana-to-idno.xsl to convert to the current encoding.
+-->
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="dracor" xml:id="tst000025" xml:lang="en">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Ham</title>
+        <title type="sub">A Tragedy</title>
+        <author>William S</author>
+      </titleStmt>
+      <publicationStmt>
+        <publisher xml:id="dracor">DraCor</publisher>
+        <idno type="URL">https://dracor.org</idno>
+        <availability>
+          <licence target="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0</licence>
+        </availability>
+      </publicationStmt>
+      <sourceDesc>
+        <bibl type="digitalSource">
+          <ref target="https://github.com/dracor-org/dracor-schema">
+            dracor-schema GitHub Repository
+          </ref>
+          <availability>
+            <licence target="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</licence>
+          </availability>
+        </bibl>
+        <bibl type="originalSource">
+          Slides of the Hebrew and Yiddish DraCor Working group meeting on
+          2022-11-14 by Daniil Skorinkin
+        </bibl>
+        <listEvent>
+          <event type="print" when="2023">
+            <desc/>
+          </event>
+          <event type="written" when="2022">
+            <desc/>
+          </event>
+        </listEvent>
+      </sourceDesc>
+    </fileDesc>
+    <profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="ham">
+            <persName>Ham</persName>
+          </person>
+          <person xml:id="medea" sex="FEMALE" ana="http://www.wikidata.org/entity/Q174278">
+            <persName>Medea</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-11-07">Describe Change!</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <front>
+      <div type="front">
+        <head>Ham, a tragedy By William S</head>
+      </div>
+    </front>
+    <body>
+      <div type="act">
+        <head>Act 1.</head>
+        <div type="scene">
+          <head>Scene 1.</head>
+          <stage>Ham and Medea.</stage>
+          <sp who="#ham">
+            <speaker>Ham.</speaker>
+            <p>Lovely Spam!</p>
+          </sp>
+          <sp who="#medea">
+            <speaker>Medea.</speaker>
+            <p>Wonderful Spam!</p>
+          </sp>
+        </div>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
Closes #130. Aligns character Wikidata ID encoding with the pattern already used for authors and plays: a bare QID in an <idno type="wikidata"> child element instead of a full URI in `@ana`.

Changes:
- Update encoding guidelines for "Characters as Realisations of Concepts"
- Fill in the character_wikidata_id (Ch5) feature description
- Add deprecation warnings (role="warning") for `@ana` on person/personGrp inside particDesc, pointing to the updated guidelines section
- Add Ch5 API feature-check constraintSpec
- Add migration stylesheet 007-ana-to-idno.xsl
- Add tests tst000024 (valid new encoding) and tst000025 (deprecated `@ana`)