### PR TITLE
Warn about empty content-bearing elements

### DIFF
--- a/dracor.odd
+++ b/dracor.odd
@@ -6558,6 +6558,53 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
+            <!--
+              Empty content-bearing elements (e.g. <title/>, <name/>,
+              <idno type="URL"/>) carry no information and should be
+              discouraged.  Structural containers (body, div, sp, castList, …)
+              are excluded because their content models already forbid empty
+              content.  The elements <p> and <l> are intentionally skipped for
+              now to avoid noise from milestone-only lines; they may be added
+              later.  <gi>desc</gi> is also excluded because it is required
+              inside <gi>event</gi> where an empty value is acceptable.
+            -->
+            <constraintSpec ident="no_empty_content_bearing_elements"
+                            scheme="schematron" mode="add" type="encoding-hint">
+              <desc>
+                Content-bearing elements such as <gi>title</gi>,
+                <gi>name</gi> or <gi>idno</gi> should not be left empty.
+              </desc>
+              <constraint>
+                <sch:rule context="tei:title | tei:titlePart | tei:name
+                                 | tei:persName | tei:forename | tei:surname
+                                 | tei:addName | tei:genName | tei:roleName
+                                 | tei:author | tei:editor | tei:docAuthor
+                                 | tei:docTitle | tei:publisher | tei:pubPlace
+                                 | tei:speaker | tei:head | tei:role
+                                 | tei:roleDesc | tei:castItem
+                                 | tei:note | tei:keywords | tei:emph
+                                 | tei:foreign | tei:argument | tei:epigraph
+                                 | tei:dateline | tei:change | tei:edition
+                                 | tei:stage | tei:idno | tei:bibl"
+                          role="warning">
+                  <sch:report test="not(normalize-space(.)) and not(*)">
+                    Element &lt;<sch:name/>&gt; should not be empty.
+                  </sch:report>
+                </sch:rule>
+                <sch:rule context="tei:ref" role="warning">
+                  <sch:report test="not(normalize-space(.)) and not(*) and not(@target)">
+                    Empty &lt;ref&gt; has no @target and no anchor text.
+                  </sch:report>
+                </sch:rule>
+                <sch:rule context="tei:date" role="warning">
+                  <sch:report test="not(normalize-space(.)) and not(*)
+                                    and not(@when|@from|@to|@notBefore|@notAfter)">
+                    Empty &lt;date&gt; should at least carry a date attribute
+                    (@when, @from, @to, @notBefore or @notAfter).
+                  </sch:report>
+                </sch:rule>
+              </constraint>
+            </constraintSpec>
             <attList>
               <attDef ident="xml:id" mode="change" usage="req">
                 <datatype>

--- a/tests/tst000027-empty-elements.xml
+++ b/tests/tst000027-empty-elements.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Empty content-bearing elements should trigger warnings.
+     Expected reports from no_empty_content_bearing_elements:
+       - <name/> in originalSource bibl
+       - <idno type="URL"/> in originalSource bibl
+       - <title></title> in originalSource bibl
+       - <note/> in the front matter
+       - <stage/> in the body
+       - <ref/> without @target in front matter
+       - <date/> without any date attribute in profileDesc
+     The empty <licence/> with a @target is accepted by the existing
+     licence_target_url rule.
+     Reference: https://github.com/dracor-org/dracor-schema/issues/131
+-->
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="dracor" xml:id="tst000027" xml:lang="en">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Ham</title>
+        <title type="sub">A Tragedy</title>
+        <author>William S</author>
+      </titleStmt>
+      <publicationStmt>
+        <publisher xml:id="dracor">DraCor</publisher>
+        <idno type="URL">https://dracor.org</idno>
+        <availability>
+          <licence target="https://creativecommons.org/publicdomain/zero/1.0/"/>
+        </availability>
+      </publicationStmt>
+      <sourceDesc>
+        <bibl type="digitalSource">
+          <ref target="https://github.com/dracor-org/dracor-schema">
+            dracor-schema GitHub Repository
+          </ref>
+          <availability>
+            <licence target="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</licence>
+          </availability>
+        </bibl>
+        <bibl type="originalSource">
+          <name/>
+          <idno type="URL"/>
+          <title></title>
+        </bibl>
+      </sourceDesc>
+    </fileDesc>
+    <profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="ham">
+            <persName>Ham</persName>
+          </person>
+          <person xml:id="egg">
+            <persName>Egg</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+      <creation>
+        <date/>
+      </creation>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2026-07-30">Describe Change!</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <front>
+      <div type="front">
+        <head>Ham, a tragedy By William S</head>
+        <note/>
+        <p>See <ref/> for details.</p>
+      </div>
+      <castList>
+        <head>Dramatis Personae</head>
+        <castItem>Ham</castItem>
+        <castItem>Egg</castItem>
+      </castList>
+    </front>
+    <body>
+      <div type="act">
+        <head>Act 1.</head>
+        <div type="scene">
+          <head>Scene 1.</head>
+          <stage/>
+          <sp who="#ham">
+            <speaker>Ham.</speaker>
+            <p>Lovely Spam!</p>
+          </sp>
+          <sp who="#egg">
+            <speaker>Egg.</speaker>
+            <p>Wonderful Spam!</p>
+          </sp>
+        </div>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
Adds a Schematron rule that reports empty occurrences of content-bearing elements such as `<title>`, `<name>`, `<idno>`, `<head>`, `<speaker>`, `<stage>`, etc.  Also flags empty `<ref>` without `@target` and empty `<date>` without
any date attribute.

Structural containers whose content models already require non-empty content, as well as `<p>`, `<l>` and `<desc>`, are excluded.

Fixes #131.
