### PR TITLE
Enable editorial markup

### DIFF
--- a/dracor.odd
+++ b/dracor.odd
@@ -3356,6 +3356,10 @@
           <moduleRef key="corpus" include="particDesc"/>
           <moduleRef key="figures" include="figure figDesc table row cell"/>
           <moduleRef key="analysis"/>
+          <!-- members of model.global.edit; <gap> is already available via
+               the core module.  <app> and <witDetail> are intentionally
+               excluded as critical apparatus features not needed by DraCor. -->
+          <moduleRef key="transcr" include="addSpan damageSpan delSpan ellipsis space"/>
           <classSpec module="tei" xml:id="GLOBAL" type="atts" ident="att.global" mode="change">
             <desc xml:lang="en">
               provides a set of attributes common to all elements in the

--- a/tests/tst000028-editorial-spans.xml
+++ b/tests/tst000028-editorial-spans.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Valid play using members of model.global.edit newly enabled by the
+     transcr moduleRef: addSpan, damageSpan, delSpan, ellipsis, space.
+     <gap> comes from the core module and is already available.
+-->
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="dracor" xml:id="tst000028" xml:lang="en">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Ham</title>
+        <title type="sub">A Tragedy</title>
+        <author>William S</author>
+      </titleStmt>
+      <publicationStmt>
+        <publisher xml:id="dracor">DraCor</publisher>
+        <idno type="URL">https://dracor.org</idno>
+        <availability>
+          <licence target="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0</licence>
+        </availability>
+      </publicationStmt>
+      <sourceDesc>
+        <bibl type="digitalSource">
+          <ref target="https://github.com/dracor-org/dracor-schema">
+            dracor-schema GitHub Repository
+          </ref>
+          <availability>
+            <licence target="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</licence>
+          </availability>
+        </bibl>
+        <bibl type="originalSource">
+          Editorial-span demonstration fixture.
+        </bibl>
+      </sourceDesc>
+    </fileDesc>
+    <profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="ham">
+            <persName>Ham</persName>
+          </person>
+          <person xml:id="egg">
+            <persName>Egg</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="act">
+        <head>Act 1.</head>
+        <div type="scene">
+          <head>Scene 1.</head>
+          <delSpan spanTo="#end-of-cut"/>
+          <sp who="#ham">
+            <speaker>Ham.</speaker>
+            <p>Lovely <del>Spam</del><add>Ham</add>!</p>
+          </sp>
+          <anchor xml:id="end-of-cut"/>
+          <addSpan spanTo="#end-of-insert"/>
+          <sp who="#egg">
+            <speaker>Egg.</speaker>
+            <p>Wonderful <damageSpan spanTo="#end-of-damage"/>Spam<anchor xml:id="end-of-damage"/>!</p>
+          </sp>
+          <anchor xml:id="end-of-insert"/>
+          <sp who="#ham">
+            <speaker>Ham.</speaker>
+            <p>Egg! <gap reason="illegible" quantity="2" unit="words"/>
+              Sausage, <space quantity="3" unit="chars"/> and Bacon!
+              <ellipsis><desc>trailing dialogue omitted</desc></ellipsis></p>
+          </sp>
+        </div>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
Add a moduleRef for transcr including `addSpan`, `damageSpan`, `delSpan`, `ellipsis` and `space`, so that encoders can mark up longer editorial interventions than the inline `add`/`del` allow.  `gap` was already available via the core module.  `app` and `witDetail` are omitted as critical apparatus features not needed by DraCor.

While this should primarily solve #140 it will also reduce the validation errors in other corpora where this kind of markup is frequently used.